### PR TITLE
Renaming & Refactoring (See #4)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.6.1"
 authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 license = "Apache-2.0/MIT"
 
-description = "Simple bit field trait providing get_bit, get_range, set_bit, and set_range methods for unsigned integers."
+description = "Simple bit field trait providing get_bit, get_bits, set_bit, and set_bits methods for Rust's integral types."
 keywords = ["no_std"]
 repository = "https://github.com/phil-opp/rust-bit-field"
 documentation = "https://docs.rs/bit_field"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # bit_field
 
+A simple crate which provides the `BitField` trait, which provides methods for operating on individual bits and ranges
+of bits on Rust's integral types.
+
 ## License
 This crate is dual-licensed under MIT or the Apache License (Version 2.0). See LICENSE-APACHE and LICENSE-MIT for details.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,44 +6,21 @@
 #[cfg(test)]
 mod tests;
 
-use core::ops::{Range, Shl, Shr, BitAndAssign, BitOrAssign, Not, BitAnd, BitOr};
-use core::mem::size_of;
+use core::ops::Range;
 
 /// A generic trait which provides methods for extracting and setting specific bits or ranges of
 /// bits.
-pub trait BitField: Copy + Eq + Not<Output = Self> +
-    Shl<u8, Output = Self> + Shr<u8, Output = Self> +
-    BitAnd<Self, Output=Self> + BitOr<Self, Output=Self> + BitAndAssign + BitOrAssign
-{
-    /// Returns the zero-value of the bit field; for any integral type, this will be the literal
-    /// constant '0'.
-    ///
-    /// ```rust
-    /// use bit_field::BitField;
-    ///
-    /// assert_eq!(<u32 as BitField>::zero(), 0u32);
-    /// ```
-    fn zero() -> Self;
-
-    /// Returns the one-value of the bit field; for any integral type, this will be the literal
-    /// constant `1`.
-    ///
-    /// ```rust
-    /// use bit_field::BitField;
-    ///
-    /// assert_eq!(<u32 as BitField>::one(), 1u32);
-    /// ```
-    fn one() -> Self;
+pub trait BitField {
 
     /// Returns the length, eg number of bits, in this bit field.
     ///
     /// ```rust
     /// use bit_field::BitField;
     ///
-    /// assert_eq!(0u32.length(), 32);
-    /// assert_eq!(0u64.length(), 64);
+    /// assert_eq!(0u32.bit_length(), 32);
+    /// assert_eq!(0u64.bit_length(), 64);
     /// ```
-    fn length(&self) -> u8;
+    fn bit_length(&self) -> u8;
 
     /// Obtains the bit at the index `bit`; note that index 0 is the least significant bit, while
     /// index `length() - 1` is the most significant bit.
@@ -60,10 +37,7 @@ pub trait BitField: Copy + Eq + Not<Output = Self> +
     /// ## Panics
     ///
     /// This method will panic if the bit index is out of bounds of the bit field.
-    fn get_bit(&self, bit: u8) -> bool {
-        assert!(bit < self.length());
-        self.get_range(bit..(bit + 1)) == Self::one()
-    }
+    fn get_bit(&self, bit: u8) -> bool;
 
     /// Obtains the range of bits specified by `range`; note that index 0 is the least significant
     /// bit, while index `length() - 1` is the most significant bit.
@@ -73,25 +47,15 @@ pub trait BitField: Copy + Eq + Not<Output = Self> +
     ///
     /// let value: u32 = 0b110101;
     ///
-    /// assert_eq!(value.get_range(0..3), 0b101);
-    /// assert_eq!(value.get_range(2..6), 0b1101);
+    /// assert_eq!(value.get_bits(0..3), 0b101);
+    /// assert_eq!(value.get_bits(2..6), 0b1101);
     /// ```
     ///
     /// ## Panics
     ///
     /// This method will panic if the start or end indexes of the range are out of bounds of the
     /// bit field.
-    fn get_range(&self, range: Range<u8>) -> Self {
-        assert!(range.start < self.length());
-        assert!(range.end <= self.length());
-        assert!(range.start < range.end);
-
-        // shift away high bits
-        let bits = *self << (self.length() - range.end) >> (self.length() - range.end);
-
-        // shift away low bits
-        bits >> range.start
-    }
+    fn get_bits(&self, range: Range<u8>) -> Self;
 
     /// Sets the bit at the index `bit` to the value `value` (where true means a value of '1' and
     /// false means a value of '0'); note that index 0 is the least significant bit, while index
@@ -115,15 +79,7 @@ pub trait BitField: Copy + Eq + Not<Output = Self> +
     /// ## Panics
     ///
     /// This method will panic if the bit index is out of the bounds of the bit field.
-    fn set_bit(&mut self, bit: u8, value: bool) -> &mut Self {
-        assert!(bit < self.length());
-        if value {
-            *self |= Self::one() << bit;
-        } else {
-            *self &= !(Self::one() << bit);
-        }
-        self
-    }
+    fn set_bit(&mut self, bit: u8, value: bool) -> &mut Self;
 
     /// Sets the range of bits defined by the range `range` to the lower bits of `value`; to be
     /// specific, if the range is N bits long, the N lower bits of `value` will be used; if any of
@@ -134,10 +90,10 @@ pub trait BitField: Copy + Eq + Not<Output = Self> +
     ///
     /// let mut value = 0u32;
     ///
-    /// value.set_range(0..2, 0b11);
+    /// value.set_bits(0..2, 0b11);
     /// assert_eq!(value, 0b11);
     ///
-    /// value.set_range(0..4, 0b1010);
+    /// value.set_bits(0..4, 0b1010);
     /// assert_eq!(value, 0b1010);
     /// ```
     ///
@@ -145,38 +101,66 @@ pub trait BitField: Copy + Eq + Not<Output = Self> +
     ///
     /// This method will panic if the range is out of bounds of the bit field, or if there are `1`s 
     /// not in the lower N bits of `value`.
-    fn set_range(&mut self, range: Range<u8>, value: Self) -> &mut Self {
-        assert!(range.start < self.length());
-        assert!(range.end <= self.length());
-        assert!(range.start < range.end);
-        assert!(value << (self.length() - (range.end - range.start)) >>
-                (self.length() - (range.end - range.start)) == value,
-                "value too big");
-
-        let bitmask: Self = !(!Self::zero() << (self.length() - range.end) >>
-                              (self.length() - range.end) >>
-                              range.start << range.start);
-
-        let bits = *self & bitmask;
-
-        // set bits
-        *self = bits | (value << range.start);
-
-        self
-    }
+    fn set_bits(&mut self, range: Range<u8>, value: Self) -> &mut Self;
 }
 
-/// An internal macro used for implementing BitField on the standard unsigned integral types.
-macro_rules! bitfield_impl {
+/// An internal macro used for implementing BitField on the standard integral types.
+macro_rules! bitfield_numeric_impl {
     ($($t:ty)*) => ($(
         impl BitField for $t {
-            fn zero() -> Self { 0 }
-            fn one() -> Self { 1 }
-            fn length(&self) -> u8 {
-                size_of::<Self>() as u8 * 8
+            fn bit_length(&self) -> u8 {
+                ::core::mem::size_of::<Self>() as u8 * 8
+            }
+
+            fn get_bit(&self, bit: u8) -> bool {
+                assert!(bit < self.bit_length());
+
+                (*self & (1 << bit)) != 0
+            }
+
+            fn get_bits(&self, range: Range<u8>) -> Self {
+                assert!(range.start < self.bit_length());
+                assert!(range.end <= self.bit_length());
+                assert!(range.start < range.end);
+
+                // shift away high bits
+                let bits = *self << (self.bit_length() - range.end) >> (self.bit_length() - range.end);
+
+                // shift away low bits
+                bits >> range.start
+            }
+
+            fn set_bit(&mut self, bit: u8, value: bool) -> &mut Self {
+                assert!(bit < self.bit_length());
+
+                if value {
+                    *self |= 1 << bit;
+                } else {
+                    *self &= !(1 << bit);
+                }
+
+                self
+            }
+
+            fn set_bits(&mut self, range: Range<u8>, value: Self) -> &mut Self {
+                assert!(range.start < self.bit_length());
+                assert!(range.end <= self.bit_length());
+                assert!(range.start < range.end);
+                assert!(value << (self.bit_length() - (range.end - range.start)) >>
+                        (self.bit_length() - (range.end - range.start)) == value,
+                        "The provided value when setting a range of bits had zeros outside of the size of the range!");
+
+                let bitmask: Self = !(!0 << (self.bit_length() - range.end) >>
+                                    (self.bit_length() - range.end) >>
+                                    range.start << range.start);
+
+                // set bits
+                *self = (*self & bitmask) | (value << range.start);
+
+                self
             }
         }
     )*)
 }
 
-bitfield_impl! { u8 u16 u32 u64 usize }
+bitfield_numeric_impl! { u8 u16 u32 u64 usize i8 i16 i32 i64 isize }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@ macro_rules! bitfield_numeric_impl {
                 assert!(range.start < range.end);
                 assert!(value << (self.bit_length() - (range.end - range.start)) >>
                         (self.bit_length() - (range.end - range.start)) == value,
-                        "The provided value when setting a range of bits had zeros outside of the size of the range!");
+                        "value does not fit into bit range");
 
                 let bitmask: Self = !(!0 << (self.bit_length() - range.end) >>
                                     (self.bit_length() - range.end) >>

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,19 @@
 use BitField;
 
 #[test]
+fn test_integer_bit_lengths() {
+    assert_eq!(0u8.bit_length(), 8);
+    assert_eq!(0u16.bit_length(), 16);
+    assert_eq!(0u32.bit_length(), 32);
+    assert_eq!(0u64.bit_length(), 64);
+
+    assert_eq!(0i8.bit_length(), 8);
+    assert_eq!(0i16.bit_length(), 16);
+    assert_eq!(0i32.bit_length(), 32);
+    assert_eq!(0i64.bit_length(), 64);
+}
+
+#[test]
 fn test_set_reset_u8() {
     let mut field = 0b11110010u8;
     let mut bit_i = |i| {
@@ -48,11 +61,11 @@ fn test_read_u32() {
         assert_eq!(field.get_bit(i), false);
     }
 
-    assert_eq!(field.get_range(16..32), 0);
-    assert_eq!(field.get_range(6..16), 0b1111111111);
-    assert_eq!(field.get_range(0..6), 0b010110);
-    assert_eq!(field.get_range(0..10), 0b1111010110);
-    assert_eq!(field.get_range(5..12), 0b1111110);
+    assert_eq!(field.get_bits(16..32), 0);
+    assert_eq!(field.get_bits(6..16), 0b1111111111);
+    assert_eq!(field.get_bits(0..6), 0b010110);
+    assert_eq!(field.get_bits(0..10), 0b1111010110);
+    assert_eq!(field.get_bits(5..12), 0b1111110);
 }
 
 #[test]
@@ -74,19 +87,19 @@ fn test_set_reset_u32() {
 #[test]
 fn test_set_range_u32() {
     let mut field = 0b1111111111010110u32;
-    field.set_range(10..15, 0b00000);
-    assert_eq!(field.get_range(10..15), 0b00000);
-    field.set_range(10..15, 0b10101);
-    assert_eq!(field.get_range(10..15), 0b10101);
-    field.set_range(10..15, 0b01010);
-    assert_eq!(field.get_range(10..15), 0b01010);
-    field.set_range(10..15, 0b11111);
-    assert_eq!(field.get_range(10..15), 0b11111);
+    field.set_bits(10..15, 0b00000);
+    assert_eq!(field.get_bits(10..15), 0b00000);
+    field.set_bits(10..15, 0b10101);
+    assert_eq!(field.get_bits(10..15), 0b10101);
+    field.set_bits(10..15, 0b01010);
+    assert_eq!(field.get_bits(10..15), 0b01010);
+    field.set_bits(10..15, 0b11111);
+    assert_eq!(field.get_bits(10..15), 0b11111);
 
-    field.set_range(0..16, 0xdead);
-    field.set_range(14..32, 0xbeaf);
-    assert_eq!(field.get_range(0..16), 0xdead);
-    assert_eq!(field.get_range(14..32), 0xbeaf);
+    field.set_bits(0..16, 0xdead);
+    field.set_bits(14..32, 0xbeaf);
+    assert_eq!(field.get_bits(0..16), 0xdead);
+    assert_eq!(field.get_bits(14..32), 0xbeaf);
 }
 
 #[test]
@@ -108,12 +121,12 @@ fn test_read_u64() {
         assert_eq!(field.get_bit(i), false);
     }
 
-    assert_eq!(field.get_range(0..32), 0);
-    assert_eq!(field.get_range(48..64), 0);
-    assert_eq!(field.get_range(38..48), 0b1111111111);
-    assert_eq!(field.get_range(32..38), 0b010110);
-    assert_eq!(field.get_range(32..42), 0b1111010110);
-    assert_eq!(field.get_range(37..44), 0b1111110);
+    assert_eq!(field.get_bits(0..32), 0);
+    assert_eq!(field.get_bits(48..64), 0);
+    assert_eq!(field.get_bits(38..48), 0b1111111111);
+    assert_eq!(field.get_bits(32..38), 0b010110);
+    assert_eq!(field.get_bits(32..42), 0b1111010110);
+    assert_eq!(field.get_bits(37..44), 0b1111110);
 }
 
 #[test]
@@ -135,19 +148,19 @@ fn test_set_reset_u64() {
 #[test]
 fn test_set_range_u64() {
     let mut field = 0b1111111111010110u64 << 32;
-    field.set_range(42..47, 0b00000);
-    assert_eq!(field.get_range(42..47), 0b00000);
-    field.set_range(10..15, 0b10101);
-    assert_eq!(field.get_range(10..15), 0b10101);
-    field.set_range(40..45, 0b01010);
-    assert_eq!(field.get_range(40..45), 0b01010);
-    field.set_range(40..45, 0b11111);
-    assert_eq!(field.get_range(40..45), 0b11111);
+    field.set_bits(42..47, 0b00000);
+    assert_eq!(field.get_bits(42..47), 0b00000);
+    field.set_bits(10..15, 0b10101);
+    assert_eq!(field.get_bits(10..15), 0b10101);
+    field.set_bits(40..45, 0b01010);
+    assert_eq!(field.get_bits(40..45), 0b01010);
+    field.set_bits(40..45, 0b11111);
+    assert_eq!(field.get_bits(40..45), 0b11111);
 
-    field.set_range(0..16, 0xdead);
-    field.set_range(14..32, 0xbeaf);
-    field.set_range(32..64, 0xcafebabe);
-    assert_eq!(field.get_range(0..16), 0xdead);
-    assert_eq!(field.get_range(14..32), 0xbeaf);
-    assert_eq!(field.get_range(32..64), 0xcafebabe);
+    field.set_bits(0..16, 0xdead);
+    field.set_bits(14..32, 0xbeaf);
+    field.set_bits(32..64, 0xcafebabe);
+    assert_eq!(field.get_bits(0..16), 0xdead);
+    assert_eq!(field.get_bits(14..32), 0xbeaf);
+    assert_eq!(field.get_bits(32..64), 0xcafebabe);
 }


### PR DESCRIPTION
This mostly removes the `zero()` and `one()` methods, renames `length()` to `bit_length()`, and changes `{get,set}_range` to `{get,set}_bits`. It also moves the implementation for the integers out into a macro in order to remove all of the trait requirements on BitField.

The trait as it is isn't quite generic enough to be usable for implementing bitvectors (which would operate on &[u8]), in part due to the usage of u8 for indexing (which isn't a big deal) and also due to the returntype of `get_bits`, which returns `Self` by value; we can't always return a u8-slice as the range may not be 8-bit aligned.

Anyway, this does have breaking changes (renaming), so take a look.