### PR TITLE
Added documentation + example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,30 @@
 A simple crate which provides the `BitField` trait, which provides methods for operating on individual bits and ranges
 of bits on Rust's integral types.
 
+## Documentation
+Documentation is available on [docs.rs](https://docs.rs/bit_field/0.7.0/bit_field/index.html)
+
+## Usage
+```TOML
+[dependencies]
+bit_field = "0.7.0"
+```
+
+## Example
+```rust
+extern crate bit_field;
+use bit_field::BitField;
+
+let x: u8 = 0;
+let msb = x.bit_length() - 1;
+
+x.set_bit(msb, true);
+assert_eq!(x, 0b1000_000)
+
+x.set_bits(0..4, 0b1001);
+assert_eq!(x, 0b1000_1001)
+
+```
+
 ## License
 This crate is dual-licensed under MIT or the Apache License (Version 2.0). See LICENSE-APACHE and LICENSE-MIT for details.


### PR DESCRIPTION
Hello, since your crate is well documented and docs.rs is already generating documentation for you, I thought it would be useful to include a link in the README. Also included a short example as a 'quick-start' for anybody who might be evaluating the crate. 