### PR TITLE
Fix three bugs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ bit_field = "0.7.0"
 extern crate bit_field;
 use bit_field::BitField;
 
-let x: u8 = 0;
+let mut x: u8 = 0;
 let msb = x.bit_length() - 1;
 
 x.set_bit(msb, true);
-assert_eq!(x, 0b1000_000)
+assert_eq!(x, 0b1000_0000);
 
 x.set_bits(0..4, 0b1001);
-assert_eq!(x, 0b1000_1001)
+assert_eq!(x, 0b1000_1001);
 
 ```
 


### PR DESCRIPTION
1. `x` will be mutated, so it needs to be `mut`.
2. `assert_eq!` does not return a value, so the missing semi-colon doesn't make sense.
3. Trailing zeros are significant: `0b1000_000` is not `0b1000_0000`

@minderhoud: I nearly disregarded the crate solely because of that.  I'm glad to see that the rest of the package is in a better shape already.