### PR TITLE
Bit vector

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,20 @@ pub trait BitField {
     fn set_bits(&mut self, range: Range<u8>, value: Self) -> &mut Self;
 }
 
+
+pub trait BitVector<T: BitField> {
+    fn bit_length(&self) -> usize;
+
+    fn get_bit(&self, bit: usize) -> bool;
+
+    fn get_bits(&self, range: Range<usize>) -> T;
+
+    fn set_bit(&mut self, bit: usize, value: bool);
+
+    fn set_bits(&mut self, range: Range<usize>, value: T);
+}
+
+
 /// An internal macro used for implementing BitField on the standard integral types.
 macro_rules! bitfield_numeric_impl {
     ($($t:ty)*) => ($(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,14 +106,96 @@ pub trait BitField {
 
 
 pub trait BitArray<T: BitField> {
+    /// Returns the length, eg number of bits, in this bit array.
+    ///
+    /// ```rust
+    /// use bit_field::BitArray;
+    ///
+    /// assert_eq!([0u8, 4u8, 8u8].bit_length(), 24);
+    /// assert_eq!([0u32, 5u32].bit_length(), 64);
+    /// ```
     fn bit_length(&self) -> usize;
 
+    /// Obtains the bit at the index `bit`; note that index 0 is the least significant bit, while
+    /// index `length() - 1` is the most significant bit.
+    ///
+    /// ```rust
+    /// use bit_field::BitArray;
+    ///
+    /// let value: [u32; 1] = [0b110101];
+    ///
+    /// assert_eq!(value.get_bit(1), false);
+    /// assert_eq!(value.get_bit(2), true);
+    /// ```
+    ///
+    /// ## Panics
+    ///
+    /// This method will panic if the bit index is out of bounds of the bit array.
     fn get_bit(&self, bit: usize) -> bool;
 
+    /// Obtains the range of bits specified by `range`; note that index 0 is the least significant
+    /// bit, while index `length() - 1` is the most significant bit.
+    ///
+    /// ```rust
+    /// use bit_field::BitArray;
+    ///
+    /// let value: [u32; 2] = [0b110101, 0b11];
+    ///
+    /// assert_eq!(value.get_bits(0..3), 0b101);
+    /// assert_eq!(value.get_bits(31..33), 0b10);
+    /// ```
+    ///
+    /// ## Panics
+    ///
+    /// This method will panic if the start or end indexes of the range are out of bounds of the
+    /// bit array, or if the range can't be contained by the bit field T.
     fn get_bits(&self, range: Range<usize>) -> T;
 
+    /// Sets the bit at the index `bit` to the value `value` (where true means a value of '1' and
+    /// false means a value of '0'); note that index 0 is the least significant bit, while index
+    /// `length() - 1` is the most significant bit.
+    ///
+    /// ```rust
+    /// use bit_field::BitArray;
+    ///
+    /// let mut value = [0u32];
+    ///
+    /// value.set_bit(1, true);
+    /// assert_eq!(value, [2u32]);
+    ///
+    /// value.set_bit(3, true);
+    /// assert_eq!(value, [10u32]);
+    ///
+    /// value.set_bit(1, false);
+    /// assert_eq!(value, [8u32]);
+    /// ```
+    ///
+    /// ## Panics
+    ///
+    /// This method will panic if the bit index is out of the bounds of the bit array.
     fn set_bit(&mut self, bit: usize, value: bool);
 
+    /// Sets the range of bits defined by the range `range` to the lower bits of `value`; to be
+    /// specific, if the range is N bits long, the N lower bits of `value` will be used; if any of
+    /// the other bits in `value` are set to 1, this function will panic.
+    ///
+    /// ```rust
+    /// use bit_field::BitArray;
+    ///
+    /// let mut value = [0u32, 0u32];
+    ///
+    /// value.set_bits(0..2, 0b11);
+    /// assert_eq!(value, [0b11, 0u32]);
+    ///
+    /// value.set_bits(31..35, 0b1010);
+    /// assert_eq!(value, [0x0003, 0b101]);
+    /// ```
+    ///
+    /// ## Panics
+    ///
+    /// This method will panic if the range is out of bounds of the bit array,
+    /// if the range can't be contained by the bit field T, or if there are `1`s 
+    /// not in the lower N bits of `value`.
     fn set_bits(&mut self, range: Range<usize>, value: T);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,8 @@ impl<T: BitField> BitArray<T> for [T] {
         let bit_start = (range.start % T::bit_length() as usize) as u8;
         let bit_end = (range.end % T::bit_length() as usize) as u8;
         let len = range.len() as u8;
+
+        assert!(slice_end - slice_start<= 1);
         
         if slice_start == slice_end {
             self[slice_start].get_bits(bit_start..bit_end)
@@ -223,6 +225,8 @@ impl<T: BitField> BitArray<T> for [T] {
         let slice_end = range.end / T::bit_length() as usize;
         let bit_start = (range.start % T::bit_length() as usize) as u8;
         let bit_end = (range.end % T::bit_length() as usize) as u8;
+        
+        assert!(slice_end - slice_start<= 1);
         
         if slice_start == slice_end {
             self[slice_start].set_bits(bit_start..bit_end, value);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,10 @@ pub trait BitField {
     /// ```rust
     /// use bit_field::BitField;
     ///
-    /// assert_eq!(0u32.bit_length(), 32);
-    /// assert_eq!(0u64.bit_length(), 64);
+    /// assert_eq!(u32::bit_length(), 32);
+    /// assert_eq!(u64::bit_length(), 64);
     /// ```
-    fn bit_length(&self) -> u8;
+    fn bit_length() -> u8;
 
     /// Obtains the bit at the index `bit`; note that index 0 is the least significant bit, while
     /// index `length() - 1` is the most significant bit.
@@ -108,30 +108,30 @@ pub trait BitField {
 macro_rules! bitfield_numeric_impl {
     ($($t:ty)*) => ($(
         impl BitField for $t {
-            fn bit_length(&self) -> u8 {
+            fn bit_length() -> u8 {
                 ::core::mem::size_of::<Self>() as u8 * 8
             }
 
             fn get_bit(&self, bit: u8) -> bool {
-                assert!(bit < self.bit_length());
+                assert!(bit < Self::bit_length());
 
                 (*self & (1 << bit)) != 0
             }
 
             fn get_bits(&self, range: Range<u8>) -> Self {
-                assert!(range.start < self.bit_length());
-                assert!(range.end <= self.bit_length());
+                assert!(range.start < Self::bit_length());
+                assert!(range.end <= Self::bit_length());
                 assert!(range.start < range.end);
 
                 // shift away high bits
-                let bits = *self << (self.bit_length() - range.end) >> (self.bit_length() - range.end);
+                let bits = *self << (Self::bit_length() - range.end) >> (Self::bit_length() - range.end);
 
                 // shift away low bits
                 bits >> range.start
             }
 
             fn set_bit(&mut self, bit: u8, value: bool) -> &mut Self {
-                assert!(bit < self.bit_length());
+                assert!(bit < Self::bit_length());
 
                 if value {
                     *self |= 1 << bit;
@@ -143,15 +143,15 @@ macro_rules! bitfield_numeric_impl {
             }
 
             fn set_bits(&mut self, range: Range<u8>, value: Self) -> &mut Self {
-                assert!(range.start < self.bit_length());
-                assert!(range.end <= self.bit_length());
+                assert!(range.start < Self::bit_length());
+                assert!(range.end <= Self::bit_length());
                 assert!(range.start < range.end);
-                assert!(value << (self.bit_length() - (range.end - range.start)) >>
-                        (self.bit_length() - (range.end - range.start)) == value,
+                assert!(value << (Self::bit_length() - (range.end - range.start)) >>
+                        (Self::bit_length() - (range.end - range.start)) == value,
                         "value does not fit into bit range");
 
-                let bitmask: Self = !(!0 << (self.bit_length() - range.end) >>
-                                    (self.bit_length() - range.end) >>
+                let bitmask: Self = !(!0 << (Self::bit_length() - range.end) >>
+                                    (Self::bit_length() - range.end) >>
                                     range.start << range.start);
 
                 // set bits

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ pub trait BitField {
 }
 
 
-pub trait BitVector<T: BitField> {
+pub trait BitArray<T: BitField> {
     fn bit_length(&self) -> usize;
 
     fn get_bit(&self, bit: usize) -> bool;
@@ -179,7 +179,7 @@ macro_rules! bitfield_numeric_impl {
 
 bitfield_numeric_impl! { u8 u16 u32 u64 usize i8 i16 i32 i64 isize }
 
-impl<T: BitField> BitVector<T> for [T] {
+impl<T: BitField> BitArray<T> for [T] {
     fn bit_length(&self) -> usize {
         self.len() * (T::bit_length() as usize)
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,15 +2,15 @@ use BitField;
 
 #[test]
 fn test_integer_bit_lengths() {
-    assert_eq!(0u8.bit_length(), 8);
-    assert_eq!(0u16.bit_length(), 16);
-    assert_eq!(0u32.bit_length(), 32);
-    assert_eq!(0u64.bit_length(), 64);
+    assert_eq!(u8::bit_length(), 8);
+    assert_eq!(u16::bit_length(), 16);
+    assert_eq!(u32::bit_length(), 32);
+    assert_eq!(u64::bit_length(), 64);
 
-    assert_eq!(0i8.bit_length(), 8);
-    assert_eq!(0i16.bit_length(), 16);
-    assert_eq!(0i32.bit_length(), 32);
-    assert_eq!(0i64.bit_length(), 64);
+    assert_eq!(i8::bit_length(), 8);
+    assert_eq!(i16::bit_length(), 16);
+    assert_eq!(i32::bit_length(), 32);
+    assert_eq!(i64::bit_length(), 64);
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -182,7 +182,7 @@ fn test_array_length() {
 }
 
 #[test]
-fn test_get_array() {
+fn test_set_bit_array() {
     let mut test_val = [0xffu8];
     &test_val.set_bit(0,false);
     assert_eq!(test_val, [0xfeu8]);
@@ -196,3 +196,73 @@ fn test_get_array() {
 
     assert_eq!(test_array, [0x7fu8, 0x01u8, 0xfeu8]);
 }
+
+#[test]
+fn test_get_bit_array() {
+    let test_val = [0xefu8];
+    assert_eq!(test_val.get_bit(1), true);
+    assert_eq!(test_val.get_bit(4), false);
+       
+    let test_array = [0xffu8, 0x00u8, 0xffu8];
+    assert_eq!(test_array.get_bit(7), true);
+    assert_eq!(test_array.get_bit(8), false);
+    assert_eq!(test_array.get_bit(16), true);
+}
+
+#[test]
+fn test_set_bits_array() {
+    let mut test_val = [0xffu8];
+
+    test_val.set_bits(0..4, 0x0u8);
+    assert_eq!(test_val, [0xf0u8]);
+    
+    test_val.set_bits(0..4,0xau8);
+    assert_eq!(test_val, [0xfau8]);
+
+    test_val.set_bits(4..8,0xau8);
+    assert_eq!(test_val, [0xaau8]);
+
+
+
+    let mut test_array = [0xffu8, 0x00u8, 0xffu8];
+
+    test_array.set_bits(7..9, 0b10);
+    assert_eq!(test_array, [0x7f, 0x01, 0xff]);
+
+    test_array.set_bits(12..20, 0xaa);
+    assert_eq!(test_array, [0x7f, 0xa1, 0xfa]);
+
+    test_array.set_bits(16..24, 0xaa);
+    assert_eq!(test_array, [0x7f, 0xa1, 0xaa]);
+
+    test_array.set_bits(6..14, 0x00);
+    assert_eq!(test_array, [0x3f, 0x80, 0xaa]);
+}
+
+
+#[test]
+fn test_get_bits_array() {
+    let mut test_val = [0xf0u8];
+    assert_eq!(test_val.get_bits(0..4), 0x0u8);
+    
+    test_val = [0xfau8];
+    assert_eq!(test_val.get_bits(0..4), 0xau8);
+
+    test_val = [0xaau8];
+    assert_eq!(test_val.get_bits(4..8), 0xau8);
+    
+
+    let mut test_array: [u8; 3] = [0xff, 0x01, 0xff];
+    assert_eq!(test_array.get_bits(7..9), 0b11u8);
+
+    test_array = [0x7f, 0xa1, 0xfa];
+    assert_eq!(test_array.get_bits(12..20), 0xaa);
+
+    test_array = [0x7f, 0xa1, 0xaa];
+    assert_eq!(test_array.get_bits(16..24), 0xaa);
+
+    test_array = [0x3f, 0x80, 0xaa];
+    assert_eq!(test_array.get_bits(6..14), 0x00);
+
+}
+

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,5 @@
 use BitField;
+use BitArray;
 
 #[test]
 fn test_integer_bit_lengths() {
@@ -163,4 +164,35 @@ fn test_set_range_u64() {
     assert_eq!(field.get_bits(0..16), 0xdead);
     assert_eq!(field.get_bits(14..32), 0xbeaf);
     assert_eq!(field.get_bits(32..64), 0xcafebabe);
+}
+
+#[test]
+fn test_array_length() {
+    assert_eq!((&[2u8, 3u8, 4u8]).bit_length(), 24);
+    assert_eq!((&[2i8, 3i8, 4i8, 5i8]).bit_length(), 32);
+
+    assert_eq!((&[2u16, 3u16, 4u16]).bit_length(), 48);
+    assert_eq!((&[2i16, 3i16, 4i16, 5i16]).bit_length(), 64);
+    
+    assert_eq!((&[2u32, 3u32, 4u32]).bit_length(), 96);
+    assert_eq!((&[2i32, 3i32, 4i32, 5i32]).bit_length(), 128);
+
+    assert_eq!((&[2u64, 3u64, 4u64]).bit_length(), 192);
+    assert_eq!((&[2i64, 3i64, 4i64, 5i64]).bit_length(), 256);
+}
+
+#[test]
+fn test_get_array() {
+    let mut test_val = [0xffu8];
+    &test_val.set_bit(0,false);
+    assert_eq!(test_val, [0xfeu8]);
+    &test_val.set_bit(4,false);
+    assert_eq!(test_val, [0xeeu8]);
+
+    let mut test_array = [0xffu8, 0x00u8, 0xffu8];
+    &test_array.set_bit(7, false);
+    &test_array.set_bit(8, true);
+    &test_array.set_bit(16, false);
+
+    assert_eq!(test_array, [0x7fu8, 0x01u8, 0xfeu8]);
 }


### PR DESCRIPTION
Opened this pull request to bring the discussion from #8 from standstill.

First question to be adressed is: Is this something you wish to implement in this crate or should I rather create a new crate that depend on this crate (or if needed, a fork)?

Second question: Is the change from ```self.bit_length()``` to ```Self::bit_length``` acceptable, cause the alternative is to have O(n) indexing in ```[BitField]``` (as mentioned in #8) and I don't think that is better.

When all the technicalities is sorted out i will add docs and complete tests.