### PR TITLE
add #[inline] to to_regular_range

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,6 +358,7 @@ impl<T: BitField> BitArray<T> for [T] {
     }
 }
 
+#[inline]
 fn to_regular_range<T: RangeBounds<usize>>(generic_rage: &T, bit_length: usize) -> Range<usize> {
     let start = match generic_rage.start_bound() {
         Bound::Excluded(&value) => value + 1,


### PR DESCRIPTION
Generic functions can already be inlined, but the compiler may not necessarily do so. Explicitly adding the #[inline] attribute hints to the compiler that it should inline the function. Given that the function is a no-op in the best case and even in the worst case only does two simple integer additions, this function should always be inlined.