### PR TITLE
Introduce BitArray::clear() method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ documentation = "https://docs.rs/bit_field"
 
 [dependencies]
 
+[dev-dependencies]
+rstest = "0.22"
+
 [package.metadata.release]
 dev-version = false
 pre-release-replacements = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,18 @@ pub trait BitArray<T: BitField> {
     /// if the range can't be contained by the bit field T, or if there are `1`s
     /// not in the lower N bits of `value`.
     fn set_bits<U: RangeBounds<usize>>(&mut self, range: U, value: T);
+
+    /// Clears all the bits in this bit array in-place.
+    ///
+    /// ```rust
+    /// use bit_field::BitArray;
+    ///
+    /// let mut value = [1u32, 2u32, 3u32];
+    ///
+    /// value.clear();
+    /// assert_eq!(value, [0u32, 0u32, 0u32]);
+    /// ```
+    fn clear(&mut self);
 }
 
 /// An internal macro used for implementing BitField on the standard integral types.
@@ -276,7 +288,10 @@ macro_rules! bitfield_numeric_impl {
 
 bitfield_numeric_impl! { u8 u16 u32 u64 u128 usize i8 i16 i32 i64 i128 isize }
 
-impl<T: BitField> BitArray<T> for [T] {
+impl<T: BitField> BitArray<T> for [T]
+where
+    T: Default
+{
     #[inline]
     fn bit_length(&self) -> usize {
         self.len() * T::BIT_LENGTH
@@ -354,6 +369,14 @@ impl<T: BitField> BitArray<T> for [T] {
                 0..bit_end,
                 value.get_bits(T::BIT_LENGTH - bit_start..T::BIT_LENGTH),
             );
+        }
+    }
+
+    #[track_caller]
+    #[inline]
+    fn clear(&mut self) {
+        for item in self.iter_mut() {
+            *item = T::default();
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,11 @@
+use core::fmt::Debug;
 use BitArray;
 use BitField;
+
+#[cfg(test)]
+extern crate rstest;
+
+use self::rstest::*;
 
 #[test]
 fn test_integer_bit_lengths() {
@@ -337,6 +343,28 @@ fn test_set_range_u128() {
     assert_eq!(field.get_bits(..16), 0xdead);
     assert_eq!(field.get_bits(14..=31), 0xbeaf);
     assert_eq!(field.get_bits(32..), 0xcafebabe);
+}
+
+#[rstest]
+#[case(&mut [1u8, 2u8, 3u8], &[0u8, 0u8, 0u8])]
+#[case(&mut [0u8, 0u8, 0u8], &[0u8, 0u8, 0u8])]
+#[case(&mut [1u16, 2u16, 3u16], &[0u16, 0u16, 0u16])]
+#[case(&mut [0u16, 0u16, 0u16], &[0u16, 0u16, 0u16])]
+#[case(&mut [1u32, 2u32, 3u32], &[0u32, 0u32, 0u32])]
+#[case(&mut [0u32, 0u32, 0u32], &[0u32, 0u32, 0u32])]
+#[case(&mut [1u64, 2u64, 3u64], &[0u64, 0u64, 0u64])]
+#[case(&mut [0u64, 0u64, 0u64], &[0u64, 0u64, 0u64])]
+#[case(&mut [1u128, 2u128, 3u128], &[0u128, 0u128, 0u128])]
+#[case(&mut [0u128, 0u128, 0u128], &[0u128, 0u128, 0u128])]
+#[case(&mut [1isize, 2isize, 3isize], &[0isize, 0isize, 0isize])]
+#[case(&mut [0isize, 0isize, 0isize], &[0isize, 0isize, 0isize])]
+fn test_array_clear<T>(#[case] field: &mut [T], #[case] expected_result: &[T])
+where
+    T: Default + PartialEq + Debug + BitField
+{
+    field.clear();
+
+    assert_eq!(field, expected_result);
 }
 
 #[test]


### PR DESCRIPTION
I've started using this crate for my personal project recently, and I find it pretty useful.

I want to propose a couple of new methods that I find useful:
- `BitArray::clear()` - clears the array in-place.
- `BitField::highest_set_bit() -> usize` - returns highest position set to one.
- `BitField::mask_highest_set_bit()` - leaves only the highest bit set to one.
- `BitField::mask_highest_set_bits()` - leaves only the highest consecutive bits set to one.
- `BitField::lowest_set_bit() -> usize` - returns lowest position set to one.
- `BitField::mask_lowest_set_bit()` - leaves only the lowest bit set to one.
- `BitField::mask_lowest_set_bits()` - leaves only the lowest consecutive bits set to one.
- Similar methods for `BitArray` as well.

In addition to that I want to propose to use some kind of parametrized test approach to refactor the tests and make tests cover all the supported types without manually coding tests for each type.

In this PR I mainly want to showcase the proposed approach to tests using `rstest` (there are other alternatives to it) and check if the maintainers are OK with the idea of adding such methods in general.

If maintainers are OK with the test refactoring, I'd be down to gradually refactor the tests to fully cover all the supported types.